### PR TITLE
Body background now responsive

### DIFF
--- a/src/sass/_base.scss
+++ b/src/sass/_base.scss
@@ -19,6 +19,7 @@ html {
 
 body {
   background: url('./img/bg.png') no-repeat $dark;
+  background-size: cover;
   padding: 0 20px;
 }
 


### PR DESCRIPTION
#4 

Sadly, `background-position-y: ...` won't perfectly fix the gap at the bottom without making a new gap on the top due to the .png being what it is.

bg.png could be swapped out for a better image like the one linked below instead, so there's no gaps at all on the bottom of the .png. 

(Found by googling "book collage covers file:.png", with the Licensed For Reuse tool option enabled) 
https://upload.wikimedia.org/wikipedia/commons/6/67/Images_used_on_D%C3%A9couvertes_Gallimard_book_covers.jpg

It might be a cooler idea to have a div behind the contents that's set to 100vh and 100vw, with img tags of .png book covers in the div so you can randomize the bookcovers in the div, and have a finer control over how the books are displayed, like padding, margins, etc. 

Folder of bookcover .pngs named like "1.png", "2.png", etc, and have a tiny JavaScript script that randomly selects x numbers between 1 and (amount of bookcovers) then add those to the background div.