### PR TITLE
BG now full height.

### DIFF
--- a/src/sass/_base.scss
+++ b/src/sass/_base.scss
@@ -19,6 +19,7 @@ html {
 
 body {
   background: url('./img/bg.png') no-repeat $dark;
+  background-size: cover;
   padding: 0 20px;
 }
 


### PR DESCRIPTION
Used background-size: cover to do the trick. This will crop off parts of the image that don't fit in to keep the intended aspect-ratio and scale up to fill the whole screen no matter how big. 