### PR TITLE
made background image responsive to larger screen sizes

### DIFF
--- a/src/sass/_base.scss
+++ b/src/sass/_base.scss
@@ -22,6 +22,12 @@ body {
   padding: 0 20px;
 }
 
+@media screen and (min-width: 2000px) {
+  body {
+    background-size: contain;
+  }
+}
+
 #app {
   margin: 0 auto;
   display: block;


### PR DESCRIPTION
Added a media query so that the background image stretches to fill the available space when the screen size is larger than the current source file.

Fixes the large screen bug mentioned in #4 without impacting behaviour on other devices/screen sizes.